### PR TITLE
Add amplify/team-provider-info.json in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ amplify-gradle-config.json
 amplifytools.xcconfig
 .secret-*
 #amplify-do-not-edit-end
+
+# amplify misc
+amplify/team-provider-info.json


### PR DESCRIPTION
- by a guide in AWS document:
  - https://docs.amplify.aws/cli/teams/shared/#sharing-projects-within-the-team